### PR TITLE
Move eslint stuff to devDependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,14 +26,6 @@
   ],
   "author": "Andrew Zhu",
   "license": "ISC",
-  "dependencies": {
-    "@typescript-eslint/eslint-plugin": "^2.12.0",
-    "@typescript-eslint/parser": "^2.12.0",
-    "eslint": "^6.8.0",
-    "eslint-config-prettier": "^6.7.0",
-    "eslint-plugin-prettier": "^3.1.2",
-    "prettier": "^1.19.1"
-  },
   "devDependencies": {
     "@babel/plugin-proposal-decorators": "^7.7.4",
     "@babel/plugin-proposal-optional-chaining": "^7.7.5",
@@ -43,6 +35,12 @@
     "@types/node": "^12.12.21",
     "jest": "^24.9.0",
     "node-lfu-cache": "^5.0.0",
-    "typescript": "^3.7.4"
+    "typescript": "^3.7.4",
+    "@typescript-eslint/eslint-plugin": "^2.12.0",
+    "@typescript-eslint/parser": "^2.12.0",
+    "eslint": "^6.8.0",
+    "eslint-config-prettier": "^6.7.0",
+    "eslint-plugin-prettier": "^3.1.2",
+    "prettier": "^1.19.1"
   }
 }


### PR DESCRIPTION
Moving eslint and prettier to dev-dependencies so that projects which depend upon ts-memoize-decorator won't also end up depending upon these versions of eslint, prettier, etc.